### PR TITLE
change message when filter returns no insights

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -230,8 +230,9 @@ export function FunnelInvalidExclusionState(): JSX.Element {
 
 const SAVED_INSIGHTS_COPY = {
     [`${SavedInsightsTabs.All}`]: {
-        title: 'There are no insights $CONDITION.',
-        description: 'Once you create an insight, it will show up here.',
+        title: 'No insights matched your search for $CONDITION.',
+        description:
+            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
     [`${SavedInsightsTabs.Yours}`]: {
         title: "You haven't created insights $CONDITION.",

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -425,7 +425,7 @@ export function SavedInsights(): JSX.Element {
                                 ? `${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${count} insight${
                                       count === 1 ? '' : 's'
                                   }`
-                                : 'No insights yet'}
+                                : 'No matching insights'}
                         </span>
                         <div>
                             <Radio.Group


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/issues/11400
Updating empty state content/description on list of insights.

## Changes

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/4143788/185802629-9168a522-1d3e-4a68-a6e1-48cb481a1b82.png">


## How did you test this code?
1. Go to insights
2. Filter the list on a non-matching keyword.

